### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,4 +16,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: GH2DX-Xbox
-          path: gen
+          path: |
+            gen
+            default.xex

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build_xbox:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build ARK
+        run: dependencies/arkhelper dir2ark _ark gen -e -s 4073741823
+      
+      - name: Upload result
+        uses: actions/upload-artifact@v2
+        with:
+          name: GH2DX-Xbox
+          path: gen


### PR DESCRIPTION
Uses GitHub Actions to automatically compile each commit (artifact only includes the .hdr, .ark and .xex files, nothing else)